### PR TITLE
lib: libdlstat: fix memory leaks

### DIFF
--- a/usr/src/cmd/dlstat/dlstat.c
+++ b/usr/src/cmd/dlstat/dlstat.c
@@ -1534,10 +1534,11 @@ show_link_stats(datalink_id_t linkid, show_state_t state, uint32_t interval)
 			(void) show_queried_stats(handle, linkid, &state);
 		}
 
+		cleanup_removed_links(&state);
+
 		if (interval == 0)
 			break;
 
-		cleanup_removed_links(&state);
 		(void) sleep(interval);
 	}
 }

--- a/usr/src/lib/libdladm/common/libdlstat.c
+++ b/usr/src/lib/libdladm/common/libdlstat.c
@@ -595,6 +595,18 @@ static dladm_stat_desc_t  dladm_stat_table[] = {
 };
 
 /* Internal functions */
+void
+dladm_link_stat_free(dladm_stat_chain_t *curr)
+{
+	while (curr != NULL) {
+		dladm_stat_chain_t	*tofree = curr;
+
+		curr = curr->dc_next;
+		free(tofree->dc_statentry);
+		free(tofree);
+	}
+}
+
 static void *
 dlstat_diff_stats(void *arg1, void *arg2, dladm_stat_type_t stattype)
 {
@@ -1158,8 +1170,8 @@ i_dlstat_rx_bcast_stats(dladm_handle_t handle, const char *linkname)
 	head->dc_statentry = rx_lane_stat_entry;
 	head->dc_next = NULL;
 
-	free(misc_stat_entry);
 done:
+	free(misc_stat_entry);
 	return (head);
 }
 
@@ -1208,6 +1220,7 @@ i_dlstat_rx_defunctlane_stats(dladm_handle_t handle, const char *linkname)
 	head->dc_next = NULL;
 
 done:
+	free(misc_stat_entry);
 	return (head);
 }
 
@@ -1380,8 +1393,8 @@ i_dlstat_tx_bcast_stats(dladm_handle_t handle, const char *linkname)
 	head->dc_statentry = tx_lane_stat_entry;
 	head->dc_next = NULL;
 
-	free(misc_stat_entry);
 done:
+	free(misc_stat_entry);
 	return (head);
 }
 
@@ -1420,6 +1433,7 @@ i_dlstat_tx_defunctlane_stats(dladm_handle_t handle, const char *linkname)
 	head->dc_next = NULL;
 
 done:
+	free(misc_stat_entry);
 	return (head);
 }
 
@@ -1523,9 +1537,9 @@ dlstat_rx_lane_total_stats(dladm_handle_t dh, datalink_id_t linkid)
 	(void) strlcpy(total_head->dc_statheader, "mac_rx_lane_total",
 	    sizeof (total_head->dc_statheader));
 	total_head->dc_next = NULL;
-	free(rx_lane_head);
 
 done:
+	dladm_link_stat_free(rx_lane_head);
 	return (total_head);
 }
 
@@ -1567,9 +1581,9 @@ dlstat_tx_lane_total_stats(dladm_handle_t dh, datalink_id_t linkid)
 	(void) strlcpy(total_head->dc_statheader, "mac_tx_lane_total",
 	    sizeof (total_head->dc_statheader));
 	total_head->dc_next = NULL;
-	free(tx_lane_head);
 
 done:
+	dladm_link_stat_free(tx_lane_head);
 	return (total_head);
 }
 
@@ -1960,9 +1974,9 @@ dlstat_rx_ring_total_stats(dladm_handle_t dh, datalink_id_t linkid)
 	(void) strlcpy(total_head->dc_statheader, "mac_rx_ring_total",
 	    sizeof (total_head->dc_statheader));
 	total_head->dc_next = NULL;
-	free(rx_ring_head);
 
 done:
+	dladm_link_stat_free(rx_ring_head);
 	return (total_head);
 }
 
@@ -2003,9 +2017,9 @@ dlstat_tx_ring_total_stats(dladm_handle_t dh, datalink_id_t linkid)
 	(void) strlcpy(total_head->dc_statheader, "mac_tx_ring_total",
 	    sizeof (total_head->dc_statheader));
 	total_head->dc_next = NULL;
-	free(tx_ring_head);
 
 done:
+	dladm_link_stat_free(tx_ring_head);
 	return (total_head);
 }
 
@@ -2039,8 +2053,8 @@ void *
 dlstat_total_stats(dladm_handle_t dh, datalink_id_t linkid)
 {
 	dladm_stat_chain_t	*head = NULL;
-	dladm_stat_chain_t	*rx_total;
-	dladm_stat_chain_t	*tx_total;
+	dladm_stat_chain_t	*rx_total = NULL;
+	dladm_stat_chain_t	*tx_total = NULL;
 	total_stat_entry_t	*total_stat_entry;
 	rx_lane_stat_entry_t	*rx_lane_stat_entry;
 	tx_lane_stat_entry_t	*tx_lane_stat_entry;
@@ -2085,10 +2099,10 @@ dlstat_total_stats(dladm_handle_t dh, datalink_id_t linkid)
 	(void) strlcpy(head->dc_statheader, "mac_lane_total",
 	    sizeof (head->dc_statheader));
 	head->dc_next = NULL;
-	free(rx_total);
-	free(tx_total);
 
 done:
+	dladm_link_stat_free(rx_total);
+	dladm_link_stat_free(tx_total);
 	return (head);
 }
 
@@ -2348,18 +2362,6 @@ dladm_link_stat_diffchain(dladm_stat_chain_t *op1, dladm_stat_chain_t *op2,
 	}
 done:
 	return (diff_head);
-}
-
-void
-dladm_link_stat_free(dladm_stat_chain_t *curr)
-{
-	while (curr != NULL) {
-		dladm_stat_chain_t	*tofree = curr;
-
-		curr = curr->dc_next;
-		free(tofree->dc_statentry);
-		free(tofree);
-	}
 }
 
 /* Query all link stats */


### PR DESCRIPTION
This patch fixes memory leaks that appear when running dlstat -i 1 command:

==547== 6,084 bytes in 117 blocks are definitely lost in loss record 16 of 30
==547==    at 0x4FF863F4: calloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F73F5: i_dlstat_tx_bcast_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8A79: dlstat_tx_lane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8B25: dlstat_tx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C44: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x805563A: do_show (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x8055912: main (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== 6,084 bytes in 117 blocks are definitely lost in loss record 17 of 30
==547==    at 0x4FF863F4: calloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F8B41: dlstat_tx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C44: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x805563A: do_show (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x8055912: main (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== 12,636 bytes in 117 blocks are definitely lost in loss record 21 of 30
==547==    at 0x4FF863F4: calloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F70B2: i_dlstat_rx_local_retrieve_stat (in /lib/libdladm.so.1)
==547==    by 0x4F9F6CC2: i_dlstat_query_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F6D4B: i_dlstat_rx_local_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8779: dlstat_rx_lane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F883E: dlstat_rx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C2C: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== 12,636 bytes in 117 blocks are definitely lost in loss record 22 of 30
==547==    at 0x4FF863F4: calloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F885A: dlstat_rx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C2C: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x805563A: do_show (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x8055912: main (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== 29,016 bytes in 117 blocks are definitely lost in loss record 23 of 30
==547==    at 0x4FF863F4: calloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F717D: i_dlstat_misc_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F72BD: i_dlstat_rx_defunctlane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8793: dlstat_rx_lane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F883E: dlstat_rx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C2C: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x805563A: do_show (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== 29,016 bytes in 117 blocks are definitely lost in loss record 24 of 30
==547==    at 0x4FF863F4: calloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F717D: i_dlstat_misc_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F74B2: i_dlstat_tx_defunctlane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8A86: dlstat_tx_lane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8B25: dlstat_tx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C44: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x805563A: do_show (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== 73,944 (30,888 direct, 43,056 indirect) bytes in 117 blocks are definitely lost in loss record 28 of 30
==547==    at 0x4FF82F30: malloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F752F: i_dlstat_tx_defunctlane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8A86: dlstat_tx_lane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8B25: dlstat_tx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C44: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x805563A: do_show (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x8055912: main (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== 130,572 (30,888 direct, 99,684 indirect) bytes in 117 blocks are definitely lost in loss record 30 of 30
==547==    at 0x4FF82F30: malloc (in /opt/ooce/valgrind/libexec/amd64/valgrind/vgpreload_memcheck-x86-solaris.so)
==547==    by 0x4F9F7252: i_dlstat_rx_bcast_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8786: dlstat_rx_lane_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F883E: dlstat_rx_lane_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F8C2C: dlstat_total_stats (in /lib/libdladm.so.1)
==547==    by 0x4F9F9128: dladm_link_stat_query (in /lib/libdladm.so.1)
==547==    by 0x8053FBF: query_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x80540C7: show_queried_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x4F9F082B: dladm_walk_datalink_id (in /lib/libdladm.so.1)
==547==    by 0x8054133: show_link_stats (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x805563A: do_show (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==    by 0x8055912: main (in /build/illumos-omnios/usr/src/cmd/dlstat/dlstat)
==547==
==547== LEAK SUMMARY:
==547==    definitely lost: 157,248 bytes in 936 blocks
==547==    indirectly lost: 142,740 bytes in 936 blocks
==547==      possibly lost: 0 bytes in 0 blocks
==547==    still reachable: 133,482 bytes in 874 blocks
==547==         suppressed: 0 bytes in 0 blocks
==547== Reachable blocks (those to which a pointer was found) are not shown.
==547== To see them, rerun with: --leak-check=full --show-leak-kinds=all

Following memory leaks have been fixed:

1. Missing free() call in i_dlstat_rx_defunctlane_stats() and i_dlstat_tx_defunctlane_stats() functions.
2. Free ->dc_statentry field when freeing dladm_stat_chain_t structure.
3. Use dladm_link_stat_free() instead of free() in dlstat_rx_lane_total_stats() and dlstat_tx_lane_total_stats().
4. Potential memory leaks in error code-paths.